### PR TITLE
"comma and whitespace" separated addons

### DIFF
--- a/CurseBreaker.py
+++ b/CurseBreaker.py
@@ -251,7 +251,7 @@ class TUI:
 
     def c_uninstall(self, args):
         if args:
-            addons = args.split(',')
+            addons = [addon.strip() for addon in args.split(',')]
             with tqdm(total=len(addons), bar_format='{n_fmt}/{total_fmt} |{bar}|') as pbar:
                 for addon in addons:
                     name, version = self.core.del_addon(addon)

--- a/CurseBreaker.py
+++ b/CurseBreaker.py
@@ -231,7 +231,7 @@ class TUI:
 
     def c_install(self, args):
         if args:
-            addons = args.split(',')
+            addons = [addon.strip() for addon in args.split(',')]
             with tqdm(total=len(addons), bar_format='{n_fmt}/{total_fmt} |{bar}|') as pbar:
                 for addon in addons:
                     installed, name, version = self.core.add_addon(addon)


### PR DESCRIPTION
This simple modification would make it possible to paste a _comma and space_ separated list of addons for the install command. E.g.:  
`install wowi:24976-MoncaiEquipmentCompareClassic, cf:atlaslootclassic`  
This would make the input more human readable.
It may break other stuff, not tested thoroughly.