### PR TITLE
Incorrect command in error message for c_wa_update

### DIFF
--- a/CurseBreaker.py
+++ b/CurseBreaker.py
@@ -436,8 +436,8 @@ class TUI:
                     printft(HTML('More than one WoW account detected.\nPlease use <ansiwhite>set_wa_wow_account</ansiwh'
                                  'ite> command to set the correct account name.'))
                 else:
-                    printft(HTML('\n<ansigreen>More than one WoW account detected.</ansigreen>\nPlease use <ansiwhite>t'
-                                 'oggle_wa_account</ansiwhite> command to set the correct account name.'))
+                    printft(HTML('\n<ansigreen>More than one WoW account detected.</ansigreen>\nPlease use <ansiwhite>s'
+                                 'et_wa_wow_account</ansiwhite> command to set the correct account name.'))
                 return
             if wa.accountName:
                 if not self.core.config['WAAccountName']:


### PR DESCRIPTION
When more than one account is detected, an error is fired off warning of that and informing you to set the wow account. The error was providing an incorrect command to use in one instance.