### PR TITLE
Fixed error message in wa_update

### DIFF
--- a/CurseBreaker.py
+++ b/CurseBreaker.py
@@ -495,7 +495,7 @@ class TUI:
             elif len(accounts) > 1 and self.core.config['WAAccountName'] == '':
                 if verbose:
                     self.console.print('More than one WoW account detected.\nPlease use [bold white]set_wa_wow_account['
-                                       '/white] command to set the correct account name.')
+                                       '/bold white] command to set the correct account name.')
                 else:
                     self.console.print('\n[green]More than one WoW account detected.[/green]\nPlease use [bold white]se'
                                        't_wa_wow_account[/bold white] command to set the correct account name.')


### PR DESCRIPTION
Fixed a typo causing this error for people using more than one WoW account.

CB> wa_update
KeyError: 'white'

During handling of the above exception, another exception occurred:

MarkupError: closing tag '[/white]' at position 77 doesn't match any open tag