### PR TITLE
Add Cygwin support

### DIFF
--- a/CurseBreaker.py
+++ b/CurseBreaker.py
@@ -248,7 +248,8 @@ class TUI:
                     windll.user32.ShowWindow(window, 0)
         elif 'WINDIR' in os.environ and 'WT_SESSION' not in os.environ:
             set_terminal_size(100, 50)
-            windll.kernel32.SetConsoleScreenBufferSize(windll.kernel32.GetStdHandle(-11), wintypes._COORD(100, 200))
+            if platform.system() == 'Windows':
+                windll.kernel32.SetConsoleScreenBufferSize(windll.kernel32.GetStdHandle(-11), wintypes._COORD(100, 200))
             self.console = Console(width=97)
         elif self.os == 'Darwin':
             set_terminal_size(100, 50)


### PR DESCRIPTION
With this change I was able to run CurseBreaker in cygwin with its version of python3
