### PR TITLE
Fix missing config 'AutoUpdate'

### DIFF
--- a/CB/Core.py
+++ b/CB/Core.py
@@ -62,7 +62,8 @@ class Core:
                            'WAAPIKey': '',
                            'WACompanionVersion': 0,
                            'CFCacheTimestamp': 0,
-                           'CompactMode': False}
+                           'CompactMode': False,
+                           'AutoUpdate': True}
             self.save_config()
         if not os.path.isdir('WTF-Backup') and self.config['Backup']['Enabled']:
             os.mkdir('WTF-Backup')


### PR DESCRIPTION
Just fresh installed CurseBreaker [v3.10](/AcidWeb/CurseBreaker/releases/tag/v3.10.0) and imported my existing addons with `import install`. After closing CurseBreaker and starting it up again it was crashing. I figured that the `AutoUpdate` config was missing in the `WTF/CurseBreaker.json` file.

This PR will add the missing config `AutoUpdate` and set it's default value to `True`.