### PR TITLE
Add hidden commands: enable_source & disable_source

### DIFF
--- a/CB/Core.py
+++ b/CB/Core.py
@@ -88,6 +88,16 @@ class Core:
             return
         self.config['BlockedAddonSources'].append(source)
         self.save_config()
+    
+    def url_repo_mapping(self):
+        return { "cf":"https://www.curseforge.com", "wowi":"https://www.wowinterface.com", "gh":"https://github.com"}
+    
+    def is_addon_source_blocked(self, addon_url):
+        for repo, url in self.url_repo_mapping().items():
+            if repo in self.config['BlockedAddonSources']:
+                if addon_url.startswith(url):
+                    return True
+        return False
 
     def update_config(self):
         if 'Version' not in self.config.keys() or self.config['Version'] != __version__:

--- a/CB/Core.py
+++ b/CB/Core.py
@@ -75,6 +75,18 @@ class Core:
     def save_config(self):
         with open(self.configPath, 'w') as outfile:
             json.dump(self.config, outfile, sort_keys=True, indent=4, separators=(',', ': '))
+    
+    def allow_source(self, source):
+        if source not in self.config['BlockedAddonSources']:
+            return
+        self.config['BlockedAddonSources'].remove(source)
+        self.save_config()
+    
+    def block_source(self, source):
+        if source in self.config['BlockedAddonSources']:
+            return
+        self.config['BlockedAddonSources'].append(source)
+        self.save_config()
 
     def update_config(self):
         if 'Version' not in self.config.keys() or self.config['Version'] != __version__:
@@ -113,7 +125,8 @@ class Core:
                         ['3.0.1', 'CFCacheTimestamp', 0],
                         ['3.1.10', 'CFCacheCloudFlare', {}],
                         ['3.7.0', 'CompactMode', False],
-                        ['3.10.0', 'AutoUpdate', True]]:
+                        ['3.10.0', 'AutoUpdate', True],
+                        ['3.12.0', 'BlockedAddonSources', []],]:
                 if add[1] not in self.config.keys():
                     self.config[add[1]] = add[2]
             for delete in [['1.3.0', 'URLCache'],

--- a/CurseBreaker.py
+++ b/CurseBreaker.py
@@ -292,15 +292,21 @@ class TUI:
         if not self.cfSlugs or not self.wowiSlugs:
             # noinspection PyBroadException
             try:
+                if 'cf' in self.core.config['BlockedAddonSources']:
+                    raise ValueError
                 self.cfSlugs = pickle.load(gzip.open(io.BytesIO(
-                    requests.get('https://storage.googleapis.com/cursebreaker/cfslugs.pickle.gz',
-                                 headers=HEADERS).content)))
-                self.wowiSlugs = pickle.load(gzip.open(io.BytesIO(
-                    requests.get('https://storage.googleapis.com/cursebreaker/wowislugs.pickle.gz',
-                                 headers=HEADERS).content)))
+                    requests.get('https://storage.googleapis.com/cursebreaker/cfslugs.pickle.gz',headers=HEADERS).content)))
             except Exception:
                 self.cfSlugs = []
+            # noinspection PyBroadException
+            try:
+                if 'wowi' in self.core.config['BlockedAddonSources']:
+                    raise ValueError
+                self.wowiSlugs = pickle.load(gzip.open(io.BytesIO(
+                    requests.get('https://storage.googleapis.com/cursebreaker/wowislugs.pickle.gz',headers=HEADERS).content)))
+            except Exception:
                 self.wowiSlugs = []
+    
         addons = []
         for addon in sorted(self.core.config['Addons'], key=lambda k: k['Name'].lower()):
             addons.append(addon['Name'])
@@ -365,6 +371,28 @@ class TUI:
             obj = Text.from_markup(f'{text}[bold]{dev}[/bold]')
         obj.no_wrap = True
         return obj
+    
+    def c_enable_source(self, args):
+        if args:
+            sources = args.split(" ")
+            for addon_source in sources:
+                self.console.print('[green]Enabling Source: {}\n'.format(addon_source))
+                self.core.allow_source(addon_source)
+            self.setup_completer()
+
+    def c_disable_source(self, args):
+        if args:
+            sources = args.split(" ")
+            #addon_list = self.core.config['Addons']
+            for addon_source in sources:
+                self.console.print('[green]Disabling Source: {}\n'.format(addon_source))
+                self.core.block_source(addon_source)
+            self.setup_completer()
+        else:
+            self.console.print('[green]Usage:[/green]\n\tThis command accepts an addon source to disable downloads from.'
+                                'Disabling a source this way will prevent CurseBreaker from downloading or managing'
+                                ' any addons installed this way.'
+                               '[bold white]\n Examples include:[/bold white] \n\t\t[bold white] e.g cf, wowi')
 
     def c_install(self, args, recursion=False):
         if args:

--- a/CurseBreaker.py
+++ b/CurseBreaker.py
@@ -384,6 +384,8 @@ class TUI:
             for addon_source in sources:
                 self.console.print('[green]Enabling Source: {}\n'.format(addon_source))
                 self.core.allow_source(addon_source)
+            self.cfSlugs = None
+            self.wowiSlugs = None
             self.setup_completer()
 
     def c_disable_source(self, args):
@@ -393,6 +395,8 @@ class TUI:
             for addon_source in sources:
                 self.console.print('[green]Disabling Source: {}\n'.format(addon_source))
                 self.core.block_source(addon_source)
+            self.cfSlugs = None
+            self.wowiSlugs = None
             self.setup_completer()
         else:
             self.console.print('[green]Usage:[/green]\n\tThis command accepts an addon source to disable downloads from.'
@@ -492,6 +496,10 @@ class TUI:
             while not progress.finished:
                 for addon in addons:
                     try:
+                        if self.core.is_addon_source_blocked(addon['URL']):
+                            self.table.add_row(f'[bold red]Source Blocked[/bold red]', self.parse_link(addon['Name'], addon['URL'], authors=""), self.parse_link(addon['Version'], ""))
+                            progress.update(task, advance=1, refresh=True)
+                            continue
                         name, authors, versionnew, versionold, modified, blocked, source, sourceurl, changelog, deps,\
                             dstate = self.core.update_addon(addon if isinstance(addon, str) else addon['URL'],
                                                             update, force)


### PR DESCRIPTION
Creating a PR to propose a feature (commands) that allow the disabling/enabling of addon sources.

With the ongoing "unknown" of Curseforge and overwolf, I though an ability to disable addon sources would make sense. 

When a source is disabled:
- update command skips the addon
- slugs are removed for that source