### PR TITLE
Rename executable only after successful update

### DIFF
--- a/CurseBreaker.py
+++ b/CurseBreaker.py
@@ -219,7 +219,7 @@ class TUI:
                         payload = requests.get(url, headers=HEADERS, timeout=5)
                         if self.os == 'Darwin':
                             zipfile.ZipFile(io.BytesIO(payload.content)).extractall(path=os.path.dirname(
-                                os.path.abspath(sys.executable + '.new')))
+                                os.path.abspath(sys.executable)))
                         else:
                             with open(sys.executable + '.new', 'wb') as f:
                                 if self.os == 'Windows':

--- a/CurseBreaker.py
+++ b/CurseBreaker.py
@@ -216,17 +216,18 @@ class TUI:
                             break
                     if url and StrictVersion(remoteversion[1:]) > StrictVersion(__version__):
                         self.console.print('[green]Updating CurseBreaker...[/green]')
-                        shutil.move(sys.executable, sys.executable + '.old')
                         payload = requests.get(url, headers=HEADERS, timeout=5)
                         if self.os == 'Darwin':
                             zipfile.ZipFile(io.BytesIO(payload.content)).extractall(path=os.path.dirname(
-                                os.path.abspath(sys.executable)))
+                                os.path.abspath(sys.executable + '.new')))
                         else:
-                            with open(sys.executable, 'wb') as f:
+                            with open(sys.executable + '.new', 'wb') as f:
                                 if self.os == 'Windows':
                                     f.write(payload.content)
                                 elif self.os == 'Linux':
                                     f.write(gzip.decompress(payload.content))
+                        shutil.move(sys.executable, sys.executable + '.old')
+                        shutil.move(sys.executable + '.new', sys.executable)
                         os.chmod(sys.executable, 0o775)
                         self.console.print(f'[bold green]Update complete! The application will be restarted now.'
                                            f'[/bold green]\n\n[green]Changelog:[/green]\n{changelog}\n')


### PR DESCRIPTION
If connection fails during update user was left with a "Cursebreaker.exe.old", meaning shortcuts would be broken.
Quick & dirty solution; only rename the executable after update is downloaded.