### PR TITLE
add ability to export and import from Pastebin

### DIFF
--- a/CB/Core.py
+++ b/CB/Core.py
@@ -74,7 +74,8 @@ class Core:
                            'CFCacheTimestamp': 0,
                            'CompactMode': False,
                            'AutoUpdate': True,
-                           'ShowAuthors': True}
+                           'ShowAuthors': True,
+                           'PastebinAPIKey': ''}
             self.save_config()
         if not os.path.isdir('WTF-Backup') and self.config['Backup']['Enabled']:
             os.mkdir('WTF-Backup')
@@ -122,7 +123,8 @@ class Core:
                         ['3.1.10', 'CFCacheCloudFlare', {}],
                         ['3.7.0', 'CompactMode', False],
                         ['3.10.0', 'AutoUpdate', True],
-                        ['3.12.0', 'ShowAuthors', True]]:
+                        ['3.12.0', 'ShowAuthors', True],
+                        ['3.16.0', 'PastebinAPIKey', '']]:
                 if add[1] not in self.config.keys():
                     self.config[add[1]] = add[2]
             for delete in [['1.3.0', 'URLCache'],

--- a/CB/__init__.py
+++ b/CB/__init__.py
@@ -2,7 +2,7 @@ import string
 import random
 from rich.terminal_theme import TerminalTheme
 
-__version__ = '3.15.0'
+__version__ = '3.16.0'
 __license__ = 'GPLv3'
 __copyright__ = '2019-2020, Paweł Jastrzębski <pawelj@iosphe.re>'
 __docformat__ = 'restructuredtext en'

--- a/CurseBreaker.py
+++ b/CurseBreaker.py
@@ -834,7 +834,7 @@ class TUI:
         payload = self.core.export_addons()
         url = pastebin.create_paste(payload)
         shortened_url = url.split('/')[3]
-        self.console.print(f'Addons have been imported to: {url}.\n\nYou can import using [bold white]import_remote '
+        self.console.print(f'Addons have been exported to: {url}.\n\nYou can import using [bold white]import_remote '
                            f'{shortened_url}[/bold white]', highlight=False)
 
     def c_help(self, _):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ markdown
 bbcode
 rich
 lupa
+pbwrap


### PR DESCRIPTION
Attempts to resolve #166 by adding the ability to export and import from Pastebin.

I know it doesn't _exactly_ solve the original issue, which is that the user wanted to just keep things in sync between two devices automatically. However, I think this is an acceptable compromise due to the following reason:
1. I don't believe new addons are installed that often (maybe you guys are nuts, idk)
2. Google Drive has insane restrictions about how things can be posted there. No idea about dropbox
3. Privatebin seems perfect since none of this data should be considered secret.
4. Simply typing in 8 characters for a paste id seems a lot easier than installing 32 addons on a new machine
5. This allows you to easily share with other people besides yourself as well

~~Finally, I have omitted my api key, but I am honestly inclined to just include it since:~~
~~1. I never use pastebin~~
~~2. I will never have private data on pastebin~~
~~3. I don't care if my pastebin account is compromised~~
~~4. Nobody will be posting any private data using this tool anyway~~

~~If someone can convince me that it's a bad idea to include my api key, I will have to figure out how to direct the user to create an account in pastebin and figure out how to store that api key so CurseBreaker can access it.~~

Pastes are limited to 10 per day, so I think that's not going to work 😄 

As such, I have added a Pastebin API Key to the config.

Please let me know your thoughts.