### PR TITLE
fix terminal clearing on unix

### DIFF
--- a/CB/Compat.py
+++ b/CB/Compat.py
@@ -40,7 +40,7 @@ def clear():
     if system == 'Windows':
         os.system('cls')
     else:
-        os.system('clear')
+        print('\033c', end='')
 
 
 def set_terminal_title(title):


### PR DESCRIPTION
fixes #377

Instead of calling the OS `clear` binary use a ANSI escape sequence. This should (also) offer the broadest compatibility