### PR TITLE
Fixed Plater error when profiles don't include script_data

### DIFF
--- a/CB/Wago.py
+++ b/CB/Wago.py
@@ -86,9 +86,9 @@ class PlaterParser(BaseParser):
             data = file.read()
         platerdata = loads(re.search(r'PlaterDB = {\n.*?}\n', data, re.DOTALL).group().replace('PlaterDB = {', '{', 1))
         for profile in platerdata['profiles']:
-            if data := platerdata['profiles'][profile]['script_data']:
+            if data := platerdata['profiles'][profile].get('script_data'):
                 self.parse_storage_internal(data)
-            if data := platerdata['profiles'][profile]['hook_data']:
+            if data := platerdata['profiles'][profile].get('hook_data'):
                 self.parse_storage_internal(data)
             if 'url' in platerdata['profiles'][profile]:
                 search = self.urlParser.search(platerdata['profiles'][profile]['url'])


### PR DESCRIPTION
[This plater profile](https://wago.io/ak3iS95aa/12.0.2) will cause an error when running `wago_update`:  
```python
CB> wago_update
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /home/z0n/dev/CurseBreaker/CurseBreaker.py:222 in start                                       │
│                                                                                                  │
│    219 │   │   │   │   if getattr(self, f'c_{command[0].lower()}', False):                       │
│    220 │   │   │   │   │   try:                                                                  │
│    221 │   │   │   │   │   │   self.setup_table()                                                │
│ ❱  222 │   │   │   │   │   │   getattr(self, f'c_{command[0].lower()}')(command[1].strip() if l  │
│    223 │   │   │   │   │   │   self.setup_completer()                                            │
│    224 │   │   │   │   │   except Exception as e:                                                │
│    225 │   │   │   │   │   │   self.handle_exception(e)                                          │
│                                                                                                  │
│ /home/z0n/dev/CurseBreaker/CurseBreaker.py:901 in c_wago_update                               │
│                                                                                                  │
│    898 │   │   else:                                                                             │
│    899 │   │   │   force = False                                                                 │
│    900 │   │   wago.install_companion(force)                                                     │
│ ❱  901 │   │   statuswa, statusplater, statusstash = wago.update()                               │
│    902 │   │   if verbose:                                                                       │
│    903 │   │   │   if len(statusstash) > 0:                                                      │
│    904 │   │   │   │   self.console.print('[green]WeakAuras ready to install:[/green]')          │
│                                                                                                  │
│ /home/z0n/dev/CurseBreaker/CB/Wago.py:221 in update                                           │
│                                                                                                  │
│   218 │   │   │   wa = BaseParser()                                                              │
│   219 │   │   if os.path.isdir(Path('Interface/AddOns/Plater')) and os.path.isfile(              │
│   220 │   │   │   │   Path(f'WTF/Account/{self.accountName}/SavedVariables/Plater.lua')):        │
│ ❱ 221 │   │   │   plater = PlaterParser(self.accountName)                                        │
│   222 │   │   else:                                                                              │
│   223 │   │   │   plater = BaseParser()                                                          │
│   224 │   │   statuswa = self.check_updates(wa)                                                  │
│                                                                                                  │
│ /home/z0n/dev/CurseBreaker/CB/Wago.py:72 in __init__                                          │
│                                                                                                  │
│    69 │   │   super().__init__()                                                                 │
│    70 │   │   self.accountName = accountname                                                     │
│    71 │   │   self.api = 'plater'                                                                │
│ ❱  72 │   │   self.parse_storage()                                                               │
│    73 │                                                                                          │
│    74 │   def parse_storage_internal(self, data):                                                │
│    75 │   │   for script in data:                                                                │
│                                                                                                  │
│ /home/z0n/dev/CurseBreaker/CB/Wago.py:89 in parse_storage                                     │
│                                                                                                  │
│    86 │   │   │   data = file.read()                                                             │
│    87 │   │   platerdata = loads(re.search(r'PlaterDB = {\n.*?}\n', data, re.DOTALL).group().r   │
│    88 │   │   for profile in platerdata['profiles']:                                             │
│ ❱  89 │   │   │   if data := platerdata['profiles'][profile]['script_data']:                     │
│    90 │   │   │   │   self.parse_storage_internal(data)                                          │
│    91 │   │   │   if data := platerdata['profiles'][profile]['hook_data']:                       │
│    92 │   │   │   │   self.parse_storage_internal(data)                                          │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
KeyError: 'script_data'
```

This fixes the error, I also added the same failsafe to `hook_data` for good measure.